### PR TITLE
11.2 update

### DIFF
--- a/BagSearchPlus.toc
+++ b/BagSearchPlus.toc
@@ -1,6 +1,6 @@
-## Interface: 110002
+## Interface: 110200
 ## Title: BagSearchPlus
-## Version: 11.0.2
+## Version: 11.2.0
 ## Notes: Improves the search function in bags and bank.
 ## Author: Andols
 ## Nums made me sit up all night and do this =(

--- a/Bsp.lua
+++ b/Bsp.lua
@@ -107,7 +107,7 @@ local function UpdateSearch(self)
 	end
 end
 
-for i = 1, 13 do --Bags
+for i = 1, NUM_CONTAINER_FRAMES do --Bags
 	local containerFrame = _G["ContainerFrame"..i]
 	hooksecurefunc(containerFrame,"UpdateSearchResults",UpdateSearch)
 	hooksecurefunc(containerFrame,"UpdateItems",UpdateSearch)


### PR DESCRIPTION
Blizzard removed bank bags so the number of ContainerFrames has reduced. I changed the hard coded 13 to the constant NUM_CONTAINER_FRAMES from the WOW API.